### PR TITLE
 New pt-BR translation and Bugfixes

### DIFF
--- a/inc/budget.class.php
+++ b/inc/budget.class.php
@@ -553,7 +553,7 @@ class PluginPrintercountersBudget extends CommonDropdown {
          // Get records
          $record = new PluginPrintercountersRecord();
          $records = [];
-         if (!empty($budget['end_date']) && !empty($budget['begin_date']) && $budget['entities_id'] != null) {
+         if (!empty($budget['end_date']) && !empty($budget['begin_date']) && !is_null($budget['entities_id'])) {
             $records = $record->getRecords(0, 'Printer',
                     ['order' => "`date` DESC",
                           'condition' => " AND `glpi_printers`.`entities_id` = ".$budget['entities_id']." 

--- a/inc/printer.class.php
+++ b/inc/printer.class.php
@@ -440,10 +440,27 @@ class PluginPrintercountersPrinter extends PluginPrintercountersCommonSNMPObject
       $actualValues = $this->walk(self::SNMP_MARKER_SUPPLIES_ACTUAL_CAPACITY_SLOTS);
 
       foreach ($types as $key => $type) {
-         $resultData[] = ['type'      => self::TONER_TYPE,
-                               'sub_type'  => $type,
-                               'name'      => $names[$key],
-                               'value'     => ((int) $actualValues[$key] >= 0) ? ($actualValues[$key] / ($maxValues[$key] / 100)) : null];
+         if(ctype_xdigit(preg_replace('/\s+/', '', $type)) && ctype_xdigit(preg_replace('/\s+/', '', $names[$key]))) {
+            $resultData[] = ['type' => self::TONER_TYPE,
+                                  'sub_type' => trim(pack("H*", preg_replace('/\s+/', '', $type))),
+                                  'name'     => trim(pack("H*", preg_replace('/\s+/', '', $names[$key]))),
+                                  'value'    => ((int) $actualValues[$key] >= 0) ? ($actualValues[$key] / ($maxValues[$key] / 100)) : null];
+         } elseif(ctype_xdigit(preg_replace('/\s+/', '', $type))) {
+            $resultData[] = ['type' => self::TONER_TYPE,
+                                  'sub_type' => trim(pack("H*", preg_replace('/\s+/', '', $type))),
+                                  'name'     => $names[$key],
+                                  'value'    => ((int) $actualValues[$key] >= 0) ? ($actualValues[$key] / ($maxValues[$key] / 100)) : null];
+         } elseif(ctype_xdigit(preg_replace('/\s+/', '', $names[$key]))) {
+            $resultData[] = ['type' => self::TONER_TYPE,
+                                  'sub_type' => $type,
+                                  'name'     => trim(pack("H*", preg_replace('/\s+/', '', $names[$key]))),
+                                  'value'    => ((int) $actualValues[$key] >= 0) ? ($actualValues[$key] / ($maxValues[$key] / 100)) : null];
+         } else {
+            $resultData[] = ['type' => self::TONER_TYPE,
+                                  'sub_type' => $type,
+                                  'name'     => $names[$key],
+                                  'value'    => ((int) $actualValues[$key] >= 0) ? ($actualValues[$key] / ($maxValues[$key] / 100)) : null];
+         }
       }
 
       return $resultData;

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2173,7 +2173,7 @@ class PluginPrintercountersSearch extends CommonDBTM {
                   $newrow[$j]['count'] = 1;
 
                   if (strpos($val, "$$") === false) {
-                     if ($val == Search::NULLVALUE) {
+                     if ($val !== 0 && $val == Search::NULLVALUE) {
                         $newrow[$j][0][$fieldname] = null;
                      } else {
                         $newrow[$j][0][$fieldname] = $val;

--- a/report/printercountersreport/printercountersreport.fr_FR.php
+++ b/report/printercountersreport/printercountersreport.fr_FR.php
@@ -27,4 +27,9 @@
  --------------------------------------------------------------------------
  */
 $LANG['plugin_printercounters']['printercountersreport'] = "Contradiction avec les titulaires des marchés";
+$LANG['plugin_printercounters']['printercountersreport_budget'] = "Acquisition budget";
+$LANG['plugin_printercounters']['printercountersreport_monochrome1'] = "Monochrome start date ~ 3 month";
+$LANG['plugin_printercounters']['printercountersreport_color1'] = "Color start date ~ 3 month";
+$LANG['plugin_printercounters']['printercountersreport_monochrome2'] = "Monochrome end date ~ start";
+$LANG['plugin_printercounters']['printercountersreport_color2'] = "Color end date ~ start";
 

--- a/report/printercountersreport/printercountersreport.php
+++ b/report/printercountersreport/printercountersreport.php
@@ -200,11 +200,11 @@ if ($res && $nbtot > 0) {
    showTitle($output_type, $num, __('Location'), 'location', true);
    showTitle($output_type, $num, __('Manufacturer'), 'manufacturer', true);
    showTitle($output_type, $num, __('Model'), 'model', true);
-   showTitle($output_type, $num, __('Acquisition budget', 'printercounters'), 'budget', true);
-   showTitle($output_type, $num, __('Monochrome start date ~ 3 month', 'printercounters'), 'monochrome1', false);
-   showTitle($output_type, $num, __('Color start date ~ 3 month', 'printercounters'), 'color1', false);
-   showTitle($output_type, $num, __('Monochrome end date ~ start', 'printercounters'), 'monochrome2', false);
-   showTitle($output_type, $num, __('Color end date ~ start', 'printercounters'), 'color2', false);
+   showTitle($output_type, $num, __($LANG['plugin_printercounters']['printercountersreport_budget'], 'printercounters'), 'budget', true);
+   showTitle($output_type, $num, __($LANG['plugin_printercounters']['printercountersreport_monochrome1'], 'printercounters'), 'monochrome1', false);
+   showTitle($output_type, $num, __($LANG['plugin_printercounters']['printercountersreport_color1'], 'printercounters'), 'color1', false);
+   showTitle($output_type, $num, __($LANG['plugin_printercounters']['printercountersreport_monochrome2'], 'printercounters'), 'monochrome2', false);
+   showTitle($output_type, $num, __($LANG['plugin_printercounters']['printercountersreport_color2'], 'printercounters'), 'color2', false);
    showTitle($output_type, $num, __('Cost'), 'costs', false);
    echo Search::showEndLine($output_type);
 

--- a/report/printercountersreport/printercountersreport.pt_BR.php
+++ b/report/printercountersreport/printercountersreport.pt_BR.php
@@ -26,10 +26,10 @@
  along with printercounters. If not, see <http://www.gnu.org/licenses/>.
  --------------------------------------------------------------------------
  */
-$LANG['plugin_printercounters']['printercountersreport'] = "Contradiction with the holders of markets";
-$LANG['plugin_printercounters']['printercountersreport_budget'] = "Acquisition budget";
-$LANG['plugin_printercounters']['printercountersreport_monochrome1'] = "Monochrome start date ~ 3 month";
-$LANG['plugin_printercounters']['printercountersreport_color1'] = "Color start date ~ 3 month";
-$LANG['plugin_printercounters']['printercountersreport_monochrome2'] = "Monochrome end date ~ start";
-$LANG['plugin_printercounters']['printercountersreport_color2'] = "Color end date ~ start";
+$LANG['plugin_printercounters']['printercountersreport'] = "Divergência entre monocromático e cor";
+$LANG['plugin_printercounters']['printercountersreport_budget'] = "Orçamento de aquisição";
+$LANG['plugin_printercounters']['printercountersreport_monochrome1'] = "Data de início monocromático ~ 3 meses";
+$LANG['plugin_printercounters']['printercountersreport_color1'] = "Data de início cor ~ 3 meses";
+$LANG['plugin_printercounters']['printercountersreport_monochrome2'] = "Data fim ~ início monocromático";
+$LANG['plugin_printercounters']['printercountersreport_color2'] = "Data fim ~ início cor";
 

--- a/report/printercountersreport2/printercountersreport2.en_GB.php
+++ b/report/printercountersreport2/printercountersreport2.en_GB.php
@@ -27,4 +27,5 @@
  --------------------------------------------------------------------------
  */
 $LANG['plugin_printercounters']['printercountersreport2'] = "List of printers with no statement for more than 3 months";
+$LANG['plugin_printercounters']['printercountersreport2_date'] = "Last successful record date";
 

--- a/report/printercountersreport2/printercountersreport2.fr_FR.php
+++ b/report/printercountersreport2/printercountersreport2.fr_FR.php
@@ -27,4 +27,4 @@
  --------------------------------------------------------------------------
  */
 $LANG['plugin_printercounters']['printercountersreport2'] = "Liste des imprimantes avec absence de relevé depuis plus de 3 mois";
-
+$LANG['plugin_printercounters']['printercountersreport2_date'] = "Last successful record date";

--- a/report/printercountersreport2/printercountersreport2.php
+++ b/report/printercountersreport2/printercountersreport2.php
@@ -220,7 +220,7 @@ if ($res && $nbtot > 0) {
    showTitle($output_type, $num, __('Location'), 'location', true);
    showTitle($output_type, $num, __('Manufacturer'), 'manufacturer', true);
    showTitle($output_type, $num, __('Model'), 'model', true);
-   showTitle($output_type, $num, __('Last successful record date', 'printercounters'), 'date', false);
+   showTitle($output_type, $num, __($LANG['plugin_printercounters']['printercountersreport2_date'], 'printercounters'), 'date', false);
    showTitle($output_type, $num, __('Record type', 'printercounters'), 'type', false);
    echo Search::showEndLine($output_type);
 

--- a/report/printercountersreport2/printercountersreport2.pt_BR.php
+++ b/report/printercountersreport2/printercountersreport2.pt_BR.php
@@ -26,10 +26,5 @@
  along with printercounters. If not, see <http://www.gnu.org/licenses/>.
  --------------------------------------------------------------------------
  */
-$LANG['plugin_printercounters']['printercountersreport'] = "Contradiction with the holders of markets";
-$LANG['plugin_printercounters']['printercountersreport_budget'] = "Acquisition budget";
-$LANG['plugin_printercounters']['printercountersreport_monochrome1'] = "Monochrome start date ~ 3 month";
-$LANG['plugin_printercounters']['printercountersreport_color1'] = "Color start date ~ 3 month";
-$LANG['plugin_printercounters']['printercountersreport_monochrome2'] = "Monochrome end date ~ start";
-$LANG['plugin_printercounters']['printercountersreport_color2'] = "Color end date ~ start";
+$LANG['plugin_printercounters']['printercountersreport2'] = "Lista de impressoras sem registro há mais de 3 meses";
 

--- a/report/printercountersreport2/printercountersreport2.pt_BR.php
+++ b/report/printercountersreport2/printercountersreport2.pt_BR.php
@@ -27,4 +27,4 @@
  --------------------------------------------------------------------------
  */
 $LANG['plugin_printercounters']['printercountersreport2'] = "Lista de impressoras sem registro há mais de 3 meses";
-
+$LANG['plugin_printercounters']['printercountersreport2_date'] = "Data do último registro bem-sucedido";

--- a/report/printercountersreport3/printercountersreport3.en_GB.php
+++ b/report/printercountersreport3/printercountersreport3.en_GB.php
@@ -27,4 +27,6 @@
  --------------------------------------------------------------------------
  */
 $LANG['plugin_printercounters']['printercountersreport3'] = "Complementary report";
-
+$LANG['plugin_printercounters']['printercountersreport3_confidencerate'] = "Confidence rate";
+$LANG['plugin_printercounters']['printercountersreport3_consumptionrate'] = "Consumption rate";
+$LANG['plugin_printercounters']['printercountersreport3_extrapolation'] = "Extrapolation (over 12 months) based on the month recorded";

--- a/report/printercountersreport3/printercountersreport3.fr_FR.php
+++ b/report/printercountersreport3/printercountersreport3.fr_FR.php
@@ -27,4 +27,6 @@
  --------------------------------------------------------------------------
  */
 $LANG['plugin_printercounters']['printercountersreport3'] = "Rapport complémentaire";
-
+$LANG['plugin_printercounters']['printercountersreport3_confidencerate'] = "Confidence rate";
+$LANG['plugin_printercounters']['printercountersreport3_consumptionrate'] = "Consumption rate";
+$LANG['plugin_printercounters']['printercountersreport3_extrapolation'] = "Extrapolation (over 12 months) based on the month recorded";

--- a/report/printercountersreport3/printercountersreport3.php
+++ b/report/printercountersreport3/printercountersreport3.php
@@ -170,9 +170,9 @@ if (!empty($datas)) {
       }
 
       if (!empty($total_items)) {
-         $datas['datas'][__('Confidence rate', 'printercounters')][$date] = Html::formatNumber(($success_items / $total_items) * 100)." %";
+         $datas['datas'][__($LANG['plugin_printercounters']['printercountersreport3_confidencerate'], 'printercounters')][$date] = Html::formatNumber(($success_items / $total_items) * 100)." %";
       } else {
-         $datas['datas'][__('Confidence rate', 'printercounters')][$date] = Html::formatNumber(0)." %";
+         $datas['datas'][__($LANG['plugin_printercounters']['printercountersreport3_confidencerate'], 'printercounters')][$date] = Html::formatNumber(0)." %";
       }
 
       // Total record amount
@@ -180,9 +180,9 @@ if (!empty($datas)) {
 
       // Consumption rate
       if (!empty($datas['datas'][__('Budget')][$date])) {
-         $datas['datas'][__('Consumption rate', 'printercounters')][$date] = Html::formatNumber((($datas['datas'][_n('Record amount', 'Records amount', 2, 'printercounters')][$date] / $datas['datas'][__('Budget')][$date]) * 100)).' %';
+         $datas['datas'][__($LANG['plugin_printercounters']['printercountersreport3_consumptionrate'], 'printercounters')][$date] = Html::formatNumber((($datas['datas'][_n('Record amount', 'Records amount', 2, 'printercounters')][$date] / $datas['datas'][__('Budget')][$date]) * 100)).' %';
       } else {
-         $datas['datas'][__('Consumption rate', 'printercounters')][$date] = Html::formatNumber((0)).' %';
+         $datas['datas'][__($LANG['plugin_printercounters']['printercountersreport3_consumptionrate'], 'printercounters')][$date] = Html::formatNumber((0)).' %';
       }
 
       // Budget
@@ -193,13 +193,13 @@ if (!empty($datas)) {
    }
 
    // Extrapolation
-   $extrapolation = [__('Extrapolation (over 12 months) based on the month recorded', 'printercounters') => Html::formatNumber(($total_record_amount / count($tmp_datas)) * 12)];
+   $extrapolation = [__($LANG['plugin_printercounters']['printercountersreport3_extrapolation'], 'printercounters') => Html::formatNumber(($total_record_amount / count($tmp_datas)) * 12)];
 
    // Sort values by dates
    ksort($datas['datas'][__('Budget')]);
    ksort($datas['datas'][_n('Record amount', 'Records amount', 2, 'printercounters')]);
-   ksort($datas['datas'][__('Consumption rate', 'printercounters')]);
-   ksort($datas['datas'][__('Confidence rate', 'printercounters')]);
+   ksort($datas['datas'][__($LANG['plugin_printercounters']['printercountersreport3_consumptionrate'], 'printercounters')]);
+   ksort($datas['datas'][__($LANG['plugin_printercounters']['printercountersreport3_confidencerate'], 'printercounters')]);
 
    unset($datas['datas']['successRecord']);
 

--- a/report/printercountersreport3/printercountersreport3.pt_BR.php
+++ b/report/printercountersreport3/printercountersreport3.pt_BR.php
@@ -26,10 +26,5 @@
  along with printercounters. If not, see <http://www.gnu.org/licenses/>.
  --------------------------------------------------------------------------
  */
-$LANG['plugin_printercounters']['printercountersreport'] = "Contradiction with the holders of markets";
-$LANG['plugin_printercounters']['printercountersreport_budget'] = "Acquisition budget";
-$LANG['plugin_printercounters']['printercountersreport_monochrome1'] = "Monochrome start date ~ 3 month";
-$LANG['plugin_printercounters']['printercountersreport_color1'] = "Color start date ~ 3 month";
-$LANG['plugin_printercounters']['printercountersreport_monochrome2'] = "Monochrome end date ~ start";
-$LANG['plugin_printercounters']['printercountersreport_color2'] = "Color end date ~ start";
+$LANG['plugin_printercounters']['printercountersreport3'] = "Relatório complementar";
 

--- a/report/printercountersreport3/printercountersreport3.pt_BR.php
+++ b/report/printercountersreport3/printercountersreport3.pt_BR.php
@@ -27,4 +27,6 @@
  --------------------------------------------------------------------------
  */
 $LANG['plugin_printercounters']['printercountersreport3'] = "Relatório complementar";
-
+$LANG['plugin_printercounters']['printercountersreport3_confidencerate'] = "Taxa de confiabilidade";
+$LANG['plugin_printercounters']['printercountersreport3_consumptionrate'] = "Taxa de consumo";
+$LANG['plugin_printercounters']['printercountersreport3_extrapolation'] = "Extrapolação (nos últimos meses 12 meses) com base no mês registrado";

--- a/report/printercountersreport4/printercountersreport4.en_GB.php
+++ b/report/printercountersreport4/printercountersreport4.en_GB.php
@@ -26,6 +26,6 @@
  along with printercounters. If not, see <http://www.gnu.org/licenses/>.
  --------------------------------------------------------------------------
  */
-$LANG['plugin_printercounters']['printercountersreport4']['title'] = "Counter records by printer";
-$LANG['plugin_printercounters']['printercountersreport4']['date']  = "Page number at %s";
-$LANG['plugin_printercounters']['printercountersreport4']['date2'] = "Page number from %s1 to %s2";
+$LANG['plugin_printercounters']['printercountersreport4'] = "Counter records by printer";
+$LANG['plugin_printercounters']['printercountersreport4_date']  = "Page number at %s";
+$LANG['plugin_printercounters']['printercountersreport4_date2'] = "Page number from %s to %s";

--- a/report/printercountersreport4/printercountersreport4.fr_FR.php
+++ b/report/printercountersreport4/printercountersreport4.fr_FR.php
@@ -28,4 +28,4 @@
  */
 $LANG['plugin_printercounters']['printercountersreport4'] = "Relevé de compteurs par imprimante";
 $LANG['plugin_printercounters']['printercountersreport4_date']  = "Nombre de pages au %s";
-$LANG['plugin_printercounters']['printercountersreport4_date2'] = "Nombre de pages du %s1 au %s2";
+$LANG['plugin_printercounters']['printercountersreport4_date2'] = "Nombre de pages du %s au %s";

--- a/report/printercountersreport4/printercountersreport4.pt_BR.php
+++ b/report/printercountersreport4/printercountersreport4.pt_BR.php
@@ -26,10 +26,6 @@
  along with printercounters. If not, see <http://www.gnu.org/licenses/>.
  --------------------------------------------------------------------------
  */
-$LANG['plugin_printercounters']['printercountersreport'] = "Contradiction with the holders of markets";
-$LANG['plugin_printercounters']['printercountersreport_budget'] = "Acquisition budget";
-$LANG['plugin_printercounters']['printercountersreport_monochrome1'] = "Monochrome start date ~ 3 month";
-$LANG['plugin_printercounters']['printercountersreport_color1'] = "Color start date ~ 3 month";
-$LANG['plugin_printercounters']['printercountersreport_monochrome2'] = "Monochrome end date ~ start";
-$LANG['plugin_printercounters']['printercountersreport_color2'] = "Color end date ~ start";
-
+$LANG['plugin_printercounters']['printercountersreport4'] = "Registros de contador por impressora";
+$LANG['plugin_printercounters']['printercountersreport4_date']  = "Número de página(s) em %s";
+$LANG['plugin_printercounters']['printercountersreport4_date2'] = "Número de página(s) de %s a %s";

--- a/report/printercountersreport5/printercountersreport5.php
+++ b/report/printercountersreport5/printercountersreport5.php
@@ -82,19 +82,15 @@ if (isset($_POST["display_type"])) {
    }
 }
 
-    $ip = "(SELECT name 
-            FROM `glpi_ipaddresses` 
-            WHERE mainitemtype='Printer' and items_id = (SELECT id 
-                              FROM `glpi_networknames` 
-                              WHERE items_id=`glpi_printers`.`id`))";
+    $ip = "(SELECT name
+            FROM `glpi_ipaddresses`
+            WHERE mainitemtype='Printer' and mainitems_id=`glpi_printers`.`id`)";
     $where = "";
     if(isset($_POST['glpi_printers_id']) && $_POST['glpi_printers_id'] > 0){
         $where .= " AND `glpi_printers`.`id` = ".$_POST['glpi_printers_id'];
-        $ip = "(SELECT name 
-            FROM `glpi_ipaddresses` 
-            WHERE mainitemtype='Printer' and items_id = (SELECT id 
-                              FROM `glpi_networknames` 
-                              WHERE items_id=" . $_POST['glpi_printers_id'] . "))";
+        $ip = "(SELECT name
+            FROM `glpi_ipaddresses`
+            WHERE mainitemtype='Printer' and mainitems_id=" . $_POST['glpi_printers_id'] .")";
     }
     if(isset($_POST['glpi_printermodels_id']) && $_POST['glpi_printermodels_id'] > 0){
         $where .= " AND `glpi_printermodels`.`id` = ".$_POST['glpi_printermodels_id'];

--- a/report/printercountersreport5/printercountersreport5.php
+++ b/report/printercountersreport5/printercountersreport5.php
@@ -84,21 +84,17 @@ if (isset($_POST["display_type"])) {
 
     $ip = "(SELECT name 
             FROM `glpi_ipaddresses` 
-            WHERE items_id = (SELECT id 
+            WHERE mainitemtype='Printer' and items_id = (SELECT id 
                               FROM `glpi_networknames` 
-                              WHERE items_id=(SELECT id 
-                                              FROM `glpi_networkports` 
-                                              WHERE  itemtype='Printer' and items_id=`glpi_printers`.`id`)))";
+                              WHERE items_id=`glpi_printers`.`id`))";
     $where = "";
     if(isset($_POST['glpi_printers_id']) && $_POST['glpi_printers_id'] > 0){
         $where .= " AND `glpi_printers`.`id` = ".$_POST['glpi_printers_id'];
         $ip = "(SELECT name 
             FROM `glpi_ipaddresses` 
-            WHERE items_id = (SELECT id 
+            WHERE mainitemtype='Printer' and items_id = (SELECT id 
                               FROM `glpi_networknames` 
-                              WHERE items_id=(SELECT id 
-                                              FROM `glpi_networkports` 
-                                              WHERE  itemtype='Printer' and items_id=" . $_POST['glpi_printers_id'] . ")))";
+                              WHERE items_id=" . $_POST['glpi_printers_id'] . "))";
     }
     if(isset($_POST['glpi_printermodels_id']) && $_POST['glpi_printermodels_id'] > 0){
         $where .= " AND `glpi_printermodels`.`id` = ".$_POST['glpi_printermodels_id'];

--- a/report/printercountersreport5/printercountersreport5.pt_BR.php
+++ b/report/printercountersreport5/printercountersreport5.pt_BR.php
@@ -26,10 +26,4 @@
  along with printercounters. If not, see <http://www.gnu.org/licenses/>.
  --------------------------------------------------------------------------
  */
-$LANG['plugin_printercounters']['printercountersreport'] = "Contradiction with the holders of markets";
-$LANG['plugin_printercounters']['printercountersreport_budget'] = "Acquisition budget";
-$LANG['plugin_printercounters']['printercountersreport_monochrome1'] = "Monochrome start date ~ 3 month";
-$LANG['plugin_printercounters']['printercountersreport_color1'] = "Color start date ~ 3 month";
-$LANG['plugin_printercounters']['printercountersreport_monochrome2'] = "Monochrome end date ~ start";
-$LANG['plugin_printercounters']['printercountersreport_color2'] = "Color end date ~ start";
-
+$LANG['plugin_printercounters']['printercountersreport5'] = "Relatório de contadores de impressora";


### PR DESCRIPTION
**Update search.class.php**: See #69

**Bugfix and pt-BR Translation**: A pt_BR translation was added to the columns title of reports. There was a bug at printercountersreport4.en_GB.php that shows the title of the report as "Array" because it's translation variables was defined as an Array instead of Strings. The "%s1" and "%s2" variables was replaced by "%s" and "%s" because it was printing something like "Page number from 11-18-20201 to 11-18-20202" (note the "1" and "2" after "2020").

**Update printercountersreport5.php**: (Replaced by "Fix for getting IP address for printers without a Networkname") The printercountersreport5.php report was failing to generate when a printer has 2 or more Network Ports with the SQL error: "Subquery returns more than 1 row in query". It's possible a printer have 2 or more Network Ports. This bugfix uses the 'mainitemtype' column from 'glpi_ipaddresses' table instead of 'itemtype' from 'glpi_networkports' to select the row with the IP address of the printer.

**New translations**: Translated to pt_BR missing columns from reports.

**Fix for no "Records amount" into Complementary Report**: This is a complementary fix for #69. When generating the report "Complementary report", it didn't calculate the "Records amount" when a printer is into "Root Entity" because the $budget['entities_id'] value is stored as an integer into report/printercountersreport3/printercountersreport3.php. The entity ID from "Root Entity" is 0. The script printercountersreport3.php calls the function $budget->getRecordsAmountForBudget from inc\budget.class.php that calls this->getRecordAmount. The getRecordAmount function from budget.class.php checks if the $budget['entity_id'] is empty (line 556) through $budget['entities_id'] != null, but this also considerates 0 ("Root Entity" ID) as null. Changing it to !is_null($budget['entities_id']]) checks if entities_id is not null and consider the "Root Entity" ID (0) as not null. The budget button at the plug-in menu (Tools > Printer counters) and the "Complementary report" are working normally with this fix.

**Fix for getting IP address for printers without a Networkname**: Fix to get IP address from printers that has no entry in "glpi_networknames" table.