### PR TITLE
Creation of dynamic property is deprecated and id type is integer and null is not the right type

### DIFF
--- a/inc/record.class.php
+++ b/inc/record.class.php
@@ -69,6 +69,9 @@ class PluginPrintercountersRecord extends CommonDBTM {
    var $itemtype;
    var $tags;
    var $rand = 0;
+   var $massiveaction;
+   var $fixedDisplay;
+
 
    static $rightname = 'plugin_printercounters';
 
@@ -260,7 +263,7 @@ class PluginPrintercountersRecord extends CommonDBTM {
       $dbu         = new DbUtils();
       foreach ($options as $num => $val) {
          if ($val['table'] == $dbu->getTableForItemType('PluginPrintercountersRecord') && $val['field'] == 'id') {
-            $restriction .= PluginPrintercountersSearch::addWhere('', 1, $this->getType(), $num, 'equals', null);
+            $restriction .= PluginPrintercountersSearch::addWhere('', 1, $this->getType(), $num, 'equals', 0);
          }
          if ($val['table'] == $dbu->getTableForItemType($this->itemtype) && $val['field'] == 'id') {
             $restriction .= PluginPrintercountersSearch::addWhere('AND', 0, $this->getType(), $num, 'equals', $this->items_id);


### PR DESCRIPTION
PHP8.2 doesn't like implicit variable definitions.
WHERE SQL construction with wrong type (null).